### PR TITLE
Removed parenthesis from SomeClassExample

### DIFF
--- a/README.md
+++ b/README.md
@@ -284,7 +284,7 @@
 ### Code Example ###
 ```javascript
   // for class name we use UpperCamelCase
-  class SomeClassExample () { 
+  class SomeClassExample { 
     
     // for const name we use UPPERCASE
     const CONFIG = {


### PR DESCRIPTION
Parenthesis throw a syntax error when used like this with `class`