### PR TITLE
Fixing #51

### DIFF
--- a/sections/production/detectvulnerabilities.md
+++ b/sections/production/detectvulnerabilities.md
@@ -4,8 +4,8 @@
 
 ### One Paragraph Explainer
 
-Modern node applications has tens and some time hundred dependencies. If any of the dependencies
-you use has a known security vulenrability your app is vlnurable as well.
+Modern Node applications have tens and sometimes hundreds of dependencies. If any of the dependencies
+you use has a known security vulnerability your app is vulnerable as well.
 The following tools automatically check for known security vulnerabilities in your dependencies:
 [nsp](https://www.npmjs.com/package/nsp) - Node Security Project
 [snyk](https://snyk.io/) - Continuously find & fix vulnerabilities in your dependencies
@@ -13,6 +13,6 @@ The following tools automatically check for known security vulnerabilities in yo
 <br/><br/>
 
 ### What Other Bloggers Say
-From the [StrongLoop](https://strongloop.com/strongblog/best-practices-for-express-in-production-part-one-security/):
+From the [StrongLoop](https://strongloop.com/strongblog/best-practices-for-express-in-production-part-one-security/) blog:
 
 > ...Using to manage your application’s dependencies is powerful and convenient.  But the packages that you use may contain critical security vulnerabilities that could also affect your application.  The security of your app is only as strong as the “weakest link” in your dependencies. Fortunately, there are two helpful tools you can use to ensure of the third-party packages you use: and requireSafe.  These two tools do largely the same thing, so using both might be overkill, but “better safe than sorry” are words to live by when it comes to security...

--- a/sections/production/detectvulnerabilities.md
+++ b/sections/production/detectvulnerabilities.md
@@ -1,26 +1,18 @@
-# Use tools that automatically detect vulnerabilities
+# Use tools that automatically detect vulnerable dependencies
 
 <br/><br/>
 
-
 ### One Paragraph Explainer
 
-I really love the following words from a StrongLoop’s blog: “The security of your app is only as strong as the weakest link in your dependencies”. Code dependencies in fact tend to have vulnerabilities often, even the most famous and battle tested packages. for example, a threat was detected in a previous version of Express that might expose the user to a cross-site scripting attack. Luckily, community and commercial tools (all have free plans, at least for public repositories) such as nsp and snyk can keep an automatic eye on these threats, warn the team and the later can even patch these vulnerabilities automatically
+Modern node applications has tens and some time hundred dependencies. If any of the dependencies
+you use has a known security vulenrability your app is vlnurable as well.
+The following tools automatically check for known security vulnerabilities in your dependencies:
+[nsp](https://www.npmjs.com/package/nsp) - Node Security Project
+[snyk](https://snyk.io/) - Continuously find & fix vulnerabilities in your dependencies
 
 <br/><br/>
 
 ### What Other Bloggers Say
-From the [StrongLoop](Best Practices for Express in Production):
+From the [StrongLoop](https://strongloop.com/strongblog/best-practices-for-express-in-production-part-one-security/):
 
 > ...Using to manage your application’s dependencies is powerful and convenient.  But the packages that you use may contain critical security vulnerabilities that could also affect your application.  The security of your app is only as strong as the “weakest link” in your dependencies. Fortunately, there are two helpful tools you can use to ensure of the third-party packages you use: and requireSafe.  These two tools do largely the same thing, so using both might be overkill, but “better safe than sorry” are words to live by when it comes to security...
-
-<br/><br/>
-
-### Code example: typical nginx configuration
-
-```javascript
-//using a single line of code will attach 7 protecting middleware to Express appapp.use(helmet());
-//additional configurations can be applied on demand, this one mislead the caller to think we’re using PHP 🙂
-app.use(helmet.hidePoweredBy({ setTo: 'PHP 4.2.0' }));//other middleware are not activated by default and requires explicit configuration .
-app.use(helmet.referrerPolicy({ policy: 'same-origin' }));
-````


### PR DESCRIPTION
The mentioned article is only talking about nsp and not snyk.

I thought of maybe adding this article as well -
https://www.smashingmagazine.com/2016/01/eliminating-known-security-vulnerabilities-with-snyk/

And maybe this quote - 
> Running untrusted code inside your system poses a broad security risk. Tackling it isn’t simple, but a good place to start is by addressing known vulnerabilities. These are publicly disclosed security bugs, typically found and logged by users, or intentionally found and reported by security researchers. Being public makes these issues the easiest ones for attackers to find and exploit, and so very important to address.

> Right now, roughly 14% of the top npm packages carry known vulnerabilities. The stats are far worse for full applications: over 80% of Snyk users find vulnerabilities when testing their applications. 

The only issue with it it's seem like a promotional peace for snyk and was written by one of their co-founders 