### PR TITLE
Fix code sample syntax issue for bullet 3.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -246,8 +246,8 @@
     // code block
   }
 
-  //Avoid
-  function someFunction
+  // Avoid
+  function someFunction()
   {
     // code block
   }


### PR DESCRIPTION
This PR proposes a small syntax fix for section `3.3 Start a Codeblock's Curly Braces in the Same Line`