### PR TITLE
Fix typos and improve readability on configguide.md

### DIFF
--- a/sections/projectstructre/configguide.md
+++ b/sections/projectstructre/configguide.md
@@ -3,9 +3,17 @@
 <br/><br/>
 
 
-### One Paragraph Explainer
+### Bullet Point Explainer
 
-When dealing with configuration data, many things can just annoy and slow down: (1) setting all the keys using process environment variables becomes very tedious when in need to inject 100 keys (instead of just committing those in a config file), however when dealing with files only the devops admins can not alter the behaviour without changing the code. A reliable config solution must combine both configuration files + overrides from the process variables (b) when specifying all keys in a flat JSON, it becomes frustrating to find and modify entries when the list grows bigger. An hierarchical JSON files that is grouped into section can overcome this issue + few config libraries allow to store the configuration in multiple files and take care to union all in runtime. See example below (3) storing sensitive information like DB password is obviously not recommended but no quick and handy solution exists for this challenge. Some configuraiton library allows to encrypt files, others encrypt those entries during GIT commits or simple don't store real values for those entries and specify the actual value during deployment via environment variables. (4) some advanced config scenario demand to inject configuration value via command line (vargs) or sync configuration info via centralized cache like Redis so different servers won't hold different data.
+When dealing with configuration data, many things can just annoy and slow down:
+
+- **environment vs config files**: setting all the keys using process environment variables becomes very tedious when in need to inject 100 keys (instead of just committing those in a config file), however when dealing with files only, the devops admins can not alter the behaviour without changing the code. A reliable config solution must combine both configuration files + overrides from the process variables,
+
+- **merging configurations**: when specifying all keys in a flat JSON, it becomes frustrating to find and modify entries when the list grows bigger. A hierarchical JSON files that is grouped into section can overcome this issue + few config libraries allow to store the configuration in multiple files and take care to union all in runtime. See example below,
+
+- **handling sensitive info**: storing sensitive information like DB passwords is obviously not recommended but no quick and handy solution exists for this challenge. Some configuration libraries allow to encrypt files, others encrypt those entries during GIT commits. Another solution is to simply not store real values for those entries and specify the actual value during deployment via environment variables.
+
+- **centralized configuration**: certain advanced config scenarios demand to inject configuration values via command line (vargs) or sync configuration info via centralized cache like Redis so different servers won't hold different data.
 
 Some configuration libraries can provide most of these features for free, have a look at NPM libraries like [nconf](https://www.npmjs.com/package/nconf) and [config](https://www.npmjs.com/package/config) which tick many of these requirements.
 


### PR DESCRIPTION
- fix typos (simple -> simply, configuratiun -> configuration)
- improve readability of the 4 points made in the paragraph
- update paragraph title accordingly.