### PR TITLE
Add section on healthchecks

### DIFF
--- a/README.md
+++ b/README.md
@@ -650,6 +650,19 @@ All statements above will return false if used with `===`
 
 **Otherwise:** Long deployments -> production down time & human-related error -> team unconfident and in making deployment -> less deployments and features
 
+<br/><br/>
+
+
+## ![✔] 5.17. Expose a healthcheck endpoint for dependent systems
+
+**TL;DR:** While a simple ping endpoint can tell you if an application is running, it can be more difficult if it is able to handle requests. All applications in a distributed system should expose a healthcheck endpoint that returns the overall health of the system. Such an endpoint can perform a number of different checks, such as database access, available disk space and more. A monitoring service can then periodically query that endpoint and build an overall view of the health of the system.
+
+**Otherwise:** When a distributed system grows, it can become difficult to get an accurate picture of the overall system health.
+
+
+🔗 [**Read More: Expose a healthcheck endpoint for dependent systems**](/sections/production/healthcheckendpoint.md)
+
+
 <br/><br/><br/>
 
 <p align="right"><a href="#table-of-contents">⬆ Return to top</a></p>

--- a/sections/production/healthcheckendpoint.md
+++ b/sections/production/healthcheckendpoint.md
@@ -1,0 +1,12 @@
+# Expose a healthcheck endpoint for dependent systems
+
+<br/><br/>
+
+
+### One Paragraph Explainer
+
+In a distributed system, transparency regarding instance health is of utmost importance. If a customer action fails because one system in a chain of multiple is unhealthy, it can be very difficult to know where the problem is.
+
+By exposing an endpoint that gives you a picture of the health of the system, a system monitoring application can query all involved systems to find out which ones are unhealthy and what dependent systems may be affected by an outage.
+
+[Adopt a standard schema](https://www.npmjs.com/package/express-physical) for these endpoints across your applications to easily be able to monitor the system as a whole. 


### PR DESCRIPTION
This piece of advice isn't exactly node specific, but since Node is often deployed in a microservice environment, I think it's absolutely crucial to expose system health to all dependent systems. Even if you're not in a microservice environment, being able to view system health at a glance can be a tremendous relief.

I work in a company with a fleet of 100+ services across thousands of instances. We have developed a schema that all our services have to adhere to. Part of it is to expose a healthcheck endpoint that tells you the overall health of the system, as well as information about each individual check - including dependencies. This allows us to create a graph of connected services so that if there's an outage in one system, we can see which other systems will be affected by it. It can also help us discover bottlenecks where one system may affect many others, in which case we should strive to provide fallback behaviors that allow us to at least partially function.

For the record, I'm the developer of [express-physical](https://www.npmjs.com/package/express-physical), which I linked to in the "read more" section. We use that library across all of our node services, and it has worked well for us so far.
