### PR TITLE
Add GraphQL mention to 2.5: "Document API errors..."

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,9 +154,9 @@ Read in a different language: [![CN](/assets/flags/CN.png)**CN**](/README.chines
 
 <br/><br/>
 
-## ![✔] 2.5 Document API errors using Swagger
+## ![✔] 2.5 Document RESTful API errors using Swagger
 
-**TL;DR:** Let your API callers know which errors might come in return so they can handle these thoughtfully without crashing. This is usually done with REST API documentation frameworks like Swagger
+**TL;DR:** Let your API callers know which errors might come in return so they can handle these thoughtfully without crashing. For RESTful APIs, this is usually done with documentation frameworks like Swagger. If you're using GraphQL, you can utilize your schema and comments as well.
 
 **Otherwise:** An API client might decide to crash and restart only because it received back an error it couldn’t understand. Note: the caller of your API might be you (very typical in a microservice environment)
 

--- a/README.md
+++ b/README.md
@@ -154,7 +154,7 @@ Read in a different language: [![CN](/assets/flags/CN.png)**CN**](/README.chines
 
 <br/><br/>
 
-## ![✔] 2.5 Document RESTful API errors using Swagger
+## ![✔] 2.5 Document API errors using Swagger or GraphQL
 
 **TL;DR:** Let your API callers know which errors might come in return so they can handle these thoughtfully without crashing. For RESTful APIs, this is usually done with documentation frameworks like Swagger. If you're using GraphQL, you can utilize your schema and comments as well.
 

--- a/README.md
+++ b/README.md
@@ -160,7 +160,7 @@ Read in a different language: [![CN](/assets/flags/CN.png)**CN**](/README.chines
 
 **Otherwise:** An API client might decide to crash and restart only because it received back an error it couldn’t understand. Note: the caller of your API might be you (very typical in a microservice environment)
 
-🔗 [**Read More: documenting errors in Swagger**](/sections/errorhandling/documentingusingswagger.md)
+🔗 [**Read More: documenting API errors in Swagger or GraphQL**](/sections/errorhandling/documentingusingswagger.md)
 
 <br/><br/>
 

--- a/sections/errorhandling/documentingusingswagger.md
+++ b/sections/errorhandling/documentingusingswagger.md
@@ -4,7 +4,42 @@
 
 REST APIs return results using HTTP status codes, it’s absolutely required for the API user to be aware not only about the API schema but also about potential errors – the caller may then catch an error and tactfully handle it. For example, your API documentation might state in advance that HTTP status 409 is returned when the customer name already exists (assuming the API register new users) so the caller can correspondingly render the best UX for the given situation. Swagger is a standard that defines the schema of API documentation offering an eco-system of tools that allow creating documentation easily online, see print screens below
 
-If you have already adopted GraphQL for your API endpoints, chances are that your schema already contains guarantees as to what errors should look like and how they should be handled by your client-side tooling. In addition, you can also supplement them with comment-based documentation.
+If you have already adopted GraphQL for your API endpoints, your schema already contains strict guarantees as to what errors should look like ([outlined in the spec](https://facebook.github.io/graphql/June2018/#sec-Errors)) and how they should be handled by your client-side tooling. In addition, you can also supplement them with comment-based documentation.
+
+### GraphQL Error Example
+
+> This example uses [SWAPI](https://graphql.org/swapi-graphql), the Star Wars API.
+
+```graphql
+# should fail because id is not valid
+{
+  film(id: "1ZmlsbXM6MQ==") {
+    title
+  }
+}
+```
+
+```json
+{
+  "errors": [
+    {
+      "message": "No entry in local cache for https://swapi.co/api/films/.../",
+      "locations": [
+        {
+          "line": 2,
+          "column": 3
+        }
+      ],
+      "path": [
+        "film"
+      ]
+    }
+  ],
+  "data": {
+    "film": null
+  }
+}
+```
 
 ### Blog Quote: "You have to tell your callers what errors can happen"
 

--- a/sections/errorhandling/documentingusingswagger.md
+++ b/sections/errorhandling/documentingusingswagger.md
@@ -1,4 +1,4 @@
-# Document RESTful API errors using Swagger
+# Document API errors using Swagger or GraphQL
 
 ### One Paragraph Explainer
 

--- a/sections/errorhandling/documentingusingswagger.md
+++ b/sections/errorhandling/documentingusingswagger.md
@@ -4,7 +4,7 @@
 
 REST APIs return results using HTTP status codes, it’s absolutely required for the API user to be aware not only about the API schema but also about potential errors – the caller may then catch an error and tactfully handle it. For example, your API documentation might state in advance that HTTP status 409 is returned when the customer name already exists (assuming the API register new users) so the caller can correspondingly render the best UX for the given situation. Swagger is a standard that defines the schema of API documentation offering an eco-system of tools that allow creating documentation easily online, see print screens below
 
-If you have already adopted GraphQL for your API endpoints, chances are that your schema already contains guarantees as to how errors should look and be handled by your client-side tooling, but you can add comment-based documentation as well.
+If you have already adopted GraphQL for your API endpoints, chances are that your schema already contains guarantees as to what errors should look like and how they should be handled by your client-side tooling. In addition, you can also supplement them with comment-based documentation.
 
 ### Blog Quote: "You have to tell your callers what errors can happen"
 

--- a/sections/errorhandling/documentingusingswagger.md
+++ b/sections/errorhandling/documentingusingswagger.md
@@ -1,8 +1,10 @@
-# Document API errors using Swagger
+# Document RESTful API errors using Swagger
 
 ### One Paragraph Explainer
 
 REST APIs return results using HTTP status codes, it’s absolutely required for the API user to be aware not only about the API schema but also about potential errors – the caller may then catch an error and tactfully handle it. For example, your API documentation might state in advance that HTTP status 409 is returned when the customer name already exists (assuming the API register new users) so the caller can correspondingly render the best UX for the given situation. Swagger is a standard that defines the schema of API documentation offering an eco-system of tools that allow creating documentation easily online, see print screens below
+
+If you have already adopted GraphQL for your API endpoints, chances are that your schema already contains guarantees as to how errors should look and be handled by your client-side tooling, but you can add comment-based documentation as well.
 
 ### Blog Quote: "You have to tell your callers what errors can happen"
 


### PR DESCRIPTION
Per @i0natan's request, I've added a small paragraph outlining the benefits of GraphQL for handling errors and data schemas in your APIs.