### PR TITLE
Rename 3.4 Use Semicolon to proper statement separation

### DIFF
--- a/README.md
+++ b/README.md
@@ -275,7 +275,7 @@ function someFunction()
 
 No matter if you use semicolons or not to separate your statements, knowing the common pitfalls of improper linebreaks or automatic semicolon insertion, will help you to eliminate regular syntax errors.
 
-**TL;DR:** Use ESLint to gain awareness about separation concerns. Prettier or Standardjs can automatically resolve these issues.
+**TL;DR:** Use ESLint to gain awareness about separation concerns. [Prettier](https://prettier.io/) or [Standardjs](https://standardjs.com/) can automatically resolve these issues.
 
 **Otherwise:** As seen in the previous section, JavaScript's interpreter automatically adds a semicolon at the end of a statement if there isn't one, or considers a statement as not ended where it should, which might lead to some undesired results. You can use assignments and avoid using immediate invoked function expressions to prevent most of unexpected errors.
 

--- a/README.md
+++ b/README.md
@@ -273,9 +273,9 @@ function someFunction()
 
 ## ![✔] 3.4 Separate your statements properly
 
-No matter if you use semicolons or not to separate your statements, knowing the common pitfalls of inproper linebreak or automatic semicolon insertion, will help you to eliminate regular syntax errors.
+No matter if you use semicolons or not to separate your statements, knowing the common pitfalls of improper linebreaks or automatic semicolon insertion, will help you to eliminate regular syntax errors.
 
-**TL;DR:** Use ESLint to make you aware about separation concerns. Prettier or Standardjs can automatically resolve these issues.
+**TL;DR:** Use ESLint to gain awareness about separation concerns. Prettier or Standardjs can automatically resolve these issues.
 
 **Otherwise:** As seen in the previous section, JavaScript's interpreter automatically adds a semicolon at the end of a statement if there isn't one, or considers a statement as not ended where it should, which might lead to some undesired results. You can use assignments and avoid using immediate invoked function expressions to prevent most of unexpected errors.
 
@@ -822,7 +822,7 @@ All statements above will return false if used with `===`
 
 **TL;DR:** Validate the incoming requests' body payload and ensure it meets expectations, fail fast if it doesn't. To avoid tedious validation coding within each route you may use lightweight JSON-based validation schemas such as [jsonschema](https://www.npmjs.com/package/jsonschema) or [joi](https://www.npmjs.com/package/joi)
 
-**Otherwise:** Your generosity and permissive approach greatly increases the attack surface and encourages the attacker to try out many inputs until they find some combination to crash the application
+**Otherwise:** Your generosity and permissive approach greatly increases the attack surface and encourages the attacker to try out many futs until they find some combination to crash the application
 
 🔗 [**Read More: Validate incoming JSON schemas**](/sections/security/validation.md)
 

--- a/README.md
+++ b/README.md
@@ -822,7 +822,7 @@ All statements above will return false if used with `===`
 
 **TL;DR:** Validate the incoming requests' body payload and ensure it meets expectations, fail fast if it doesn't. To avoid tedious validation coding within each route you may use lightweight JSON-based validation schemas such as [jsonschema](https://www.npmjs.com/package/jsonschema) or [joi](https://www.npmjs.com/package/joi)
 
-**Otherwise:** Your generosity and permissive approach greatly increases the attack surface and encourages the attacker to try out many futs until they find some combination to crash the application
+**Otherwise:** Your generosity and permissive approach greatly increases the attack surface and encourages the attacker to try out many inputs until they find some combination to crash the application
 
 🔗 [**Read More: Validate incoming JSON schemas**](/sections/security/validation.md)
 

--- a/README.md
+++ b/README.md
@@ -271,27 +271,47 @@ function someFunction()
 
 <br/><br/>
 
-## ![✔] 3.4 Don't Forget the Semicolon
+## ![✔] 3.4 Separate your statements properly
 
-**TL;DR:** While not unanimously agreed upon, it is still recommended to put a semicolon at the end of each statement. This will make your code more readable and explicit to other developers who read it
+No matter if you use semicolons or not to separate your statements, knowing the common pitfalls of inproper linebreak or automatic semicolon insertion, will help you to eliminate regular syntax errors.
 
-**Otherwise:** As seen in the previous section, JavaScript's interpreter automatically adds a semicolon at the end of a statement if there isn't one, or considers a statement as not ended where it should, which might lead to some undesired results
+**TL;DR:** Use ESLint to make you aware about separation concerns. Prettier or Standardjs can automatically resolve these issues.
+
+**Otherwise:** As seen in the previous section, JavaScript's interpreter automatically adds a semicolon at the end of a statement if there isn't one, or considers a statement as not ended where it should, which might lead to some undesired results. You can use assignments and avoid using immediate invoked function expressions to prevent most of unexpected errors.
 
 ### Code example
 
 ```javascript
 // Do
-const count = 2;
-(function doSomething() {
-  // do something amazing
-}());
+function doThing() {
+    // ...
+}
+
+doThing()
+
+// Do
+
+const items = [1, 2, 3]
+items.forEach(console.log)
+
+// Avoid — throws exception
+const m = new Map()
+const a = [1,2,3]
+[...m.values()].forEach(console.log)
+> [...m.values()].forEach(console.log)
+>  ^^^
+> SyntaxError: Unexpected token ...
 
 // Avoid — throws exception
 const count = 2 // it tries to run 2(), but 2 is not a function
 (function doSomething() {
   // do something amazing
 }())
+// put a semicolon before the immediate invoked function, after the const definition, save the return value of the anonymous function to a variable or avoid IIFEs alltogether
 ```
+
+🔗 [**Read more:** "Semi ESLint rule"](https://eslint.org/docs/rules/semi)
+🔗 [**Read more:** "No unexpected multiline ESLint rule"](https://eslint.org/docs/rules/no-unexpected-multiline)
 
 <br/><br/>
 


### PR DESCRIPTION
Fixes #26.

I hope I integrated all feedback from this issue, while leaving the core message intact: People should be aware how statements are separated or linked together, and that there are cases where ASI and/or semicolon do not help, if statement termination is not understood. This also leaves room for the reader to prefer semicolons or not.