### PR TITLE
fix: Typo in centralizedhandling.md files

### DIFF
--- a/sections/errorhandling/centralizedhandling.brazilian-portuguese.md
+++ b/sections/errorhandling/centralizedhandling.brazilian-portuguese.md
@@ -40,7 +40,7 @@ app.use(async (err, req, res, next) => {
 module.exports.handler = new errorHandler();
 
 function errorHandler() {
-  this.handleError = async function(error) {
+  this.handleError = async function(err) {
     await logger.logError(err);
     await sendMailToAdminIfCritical;
     await saveInOpsQueueIfCritical;

--- a/sections/errorhandling/centralizedhandling.chinese.md
+++ b/sections/errorhandling/centralizedhandling.chinese.md
@@ -44,7 +44,7 @@ app.use(function (err, req, res, next) {
 module.exports.handler = new errorHandler();
  
 function errorHandler(){
-    this.handleError = function (error) {
+    this.handleError = function (err) {
         return logger.logError(err).then(sendMailToAdminIfCritical).then(saveInOpsQueueIfCritical).then(determineIfOperationalError);
     }
 

--- a/sections/errorhandling/centralizedhandling.md
+++ b/sections/errorhandling/centralizedhandling.md
@@ -40,7 +40,7 @@ app.use(async (err, req, res, next) => {
 module.exports.handler = new errorHandler();
 
 function errorHandler() {
-  this.handleError = async function(error) {
+  this.handleError = async function(err) {
     await logger.logError(err);
     await sendMailToAdminIfCritical;
     await saveInOpsQueueIfCritical;


### PR DESCRIPTION
Fix a small typo that can cause a real application to crash or don't work as expected.

An `err` object is passed to `logger.logError(err)` but the function argument is named `error`.