### PR TITLE
fix link text

### DIFF
--- a/README.md
+++ b/README.md
@@ -291,7 +291,7 @@ my-system
 
 **Otherwise:** Due to the overwhelming amount of considerations, it's easy to make decisions based on partial information and compare apples with oranges. For example, it's believed that Fastify is a minimal web-server that should get compared with express only. In reality, it's a rich framework with many official plugins that cover many concerns
 
-🔗 [**Read More: configuration best practices**](./sections/projectstructre/choose-framework.md)
+🔗 [**Read More: choose framework**](./sections/projectstructre/choose-framework.md)
 
 ## ![✔] 1.6 Use TypeScript sparingly and thoughtfully
 


### PR DESCRIPTION
This pull request modifies the hyperlink text in the open source code from "Read More: configuration best practices" to "Read More: choose framework" in the file [./sections/projectstructre/choose-framework.md]