### PR TITLE
update reference eslint-plugin-node to eslint-plugin-n

### DIFF
--- a/README.md
+++ b/README.md
@@ -496,7 +496,7 @@ especially if the cause of the abnormal behavior is inside of the missing functi
 
 ### `📝 #updated`
 
-**TL;DR:** On top of ESLint standard rules that cover vanilla JavaScript, add Node.js specific plugins like [eslint-plugin-node](https://www.npmjs.com/package/eslint-plugin-node), [eslint-plugin-mocha](https://www.npmjs.com/package/eslint-plugin-mocha) and [eslint-plugin-node-security](https://www.npmjs.com/package/eslint-plugin-security), [eslint-plugin-require](https://www.npmjs.com/package/eslint-plugin-require), [/eslint-plugin-jest](https://www.npmjs.com/package/eslint-plugin-jest) and other useful rules
+**TL;DR:** On top of ESLint standard rules that cover vanilla JavaScript, add Node.js specific plugins like [eslint-plugin-n](https://www.npmjs.com/package/eslint-plugin-n), [eslint-plugin-mocha](https://www.npmjs.com/package/eslint-plugin-mocha) and [eslint-plugin-node-security](https://www.npmjs.com/package/eslint-plugin-security), [eslint-plugin-require](https://www.npmjs.com/package/eslint-plugin-require), [/eslint-plugin-jest](https://www.npmjs.com/package/eslint-plugin-jest) and other useful rules
 
 **Otherwise:** Many faulty Node.js code patterns might escape under the radar. For example, developers might require(variableAsPath) files with a variable given as a path which allows attackers to execute any JS script. Node.js linters can detect such patterns and complain early
 


### PR DESCRIPTION
Changed eslint-plugin-node reference to eslint-plugin-n.

The eslint plugin `eslint-plugin-node` is no longer maintained. The plugin `eslint-plugin-n` is a fork that is currently maintained and updated (see references below).

A changed only in `README.md` but I have no problem adding the change to the translations.

[eslint-plugin-n on npm](https://www.npmjs.com/package/eslint-plugin-n)
[eslint-plugin-node issue - looking for maintainers?](https://github.com/mysticatea/eslint-plugin-node/issues/300)
[eslint-plugin-node issue - Invitation to move to official eslint-community org](https://github.com/mysticatea/eslint-plugin-node/issues/341)

