### PR TITLE
chore: update github actions to v4

### DIFF
--- a/.github/workflows/lint-and-generate-html-from-markdown.yml
+++ b/.github/workflows/lint-and-generate-html-from-markdown.yml
@@ -19,10 +19,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Setup Node.js environment
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: "18"
 

--- a/.github/workflows/update-date-in-last-update-badge.yml
+++ b/.github/workflows/update-date-in-last-update-badge.yml
@@ -14,7 +14,7 @@ jobs:
     
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Update last update badge
         run: |


### PR DESCRIPTION
Required for using Node.js 20.x in CI
* Changelog for actions/checkout@v4 https://github.com/actions/checkout/blob/main/CHANGELOG.md?rgh-link-date=2024-09-04T18%3A38%3A10Z#v400
* Changelog for actions/setup-node@v4 https://github.com/actions/setup-node/releases/tag/v4.0.0

GitHub Blog post: https://github.blog/changelog/2024-03-07-github-actions-all-actions-will-run-on-node20-instead-of-node16-by-default/