### PR TITLE
Update createmaintenanceendpoint.*.md

### DIFF
--- a/sections/production/createmaintenanceendpoint.basque.md
+++ b/sections/production/createmaintenanceendpoint.basque.md
@@ -11,7 +11,7 @@ Mantentze lanen amaiera puntua oso HTTP API segurua da, aplikazioaren kodearen p
 ### Kode adibidea: kodearen bidez pilaketa sorta sortzea
 
 ```javascript
-const heapdump = require("heapdump");
+const fs = require("fs");
 
 // Egiaztatu ia eskaera baimendua den
 function baimenaDu(req) {
@@ -25,6 +25,7 @@ router.get("/ops/heapdump", (req, res, next) => {
 
   logger.info("heapdump-a generatzen");
 
+  const heapdump = require("heapdump");
   heapdump.writeSnapshot((err, fitxategiarenIzena) => {
     console.log(
       "heapdump fitxategia prest dago eskariari bidaltzeko",
@@ -32,6 +33,7 @@ router.get("/ops/heapdump", (req, res, next) => {
     );
     fs.readFile(fitxategiarenIzena, "utf-8", (err, data) => {
       res.end(data);
+      fs.unlinkSync(filename);
     });
   });
 });

--- a/sections/production/createmaintenanceendpoint.brazilian-portuguese.md
+++ b/sections/production/createmaintenanceendpoint.brazilian-portuguese.md
@@ -11,7 +11,7 @@ Um endpoint de manutenção é uma API HTTP altamente seguro que faz parte do c�
 ### Exemplo de código: gerando um despejo de heap via código
 
 ```javascript
-const heapdump = require('heapdump');
+const fs = require("fs");
 
 // Verifique se o pedido está autorizado
 function isAuthorized(req) {
@@ -25,10 +25,12 @@ router.get('/ops/heapdump', (req, res, next) => {
 
     logger.info('Prestes a gerar o heapdump');
 
+    const heapdump = require('heapdump');
     heapdump.writeSnapshot((err, filename) => {
         console.log('arquivo heapdump está pronto para ser enviado para o chamador', filename);
         fs.readFile(filename, "utf-8", (err, data) => {
             res.end(data);
+            fs.unlinkSync(filename);
         });
     });
 });

--- a/sections/production/createmaintenanceendpoint.chinese.md
+++ b/sections/production/createmaintenanceendpoint.chinese.md
@@ -13,14 +13,26 @@
 ### 代码示例: 使用代码生产head dump
 
 ```javascript
-var heapdump = require('heapdump');
- 
-router.get('/ops/headump', (req, res, next) => {
-    logger.info(`About to generate headump`);
-    heapdump.writeSnapshot(function (err, filename) {
-        console.log('headump file is ready to be sent to the caller', filename);
-        fs.readFile(filename, "utf-8", function (err, data) {
+const fs = require("fs");
+
+// Check if request is authorized
+function isAuthorized(req) {
+    // ...
+}
+
+router.get('/ops/heapdump', (req, res, next) => {
+    if (!isAuthorized(req)) {
+        return res.status(403).send('You are not authorized!');
+    }
+
+    logger.info('About to generate heapdump');
+
+    const heapdump = require('heapdump');
+    heapdump.writeSnapshot((err, filename) => {
+        console.log('heapdump file is ready to be sent to the caller', filename);
+        fs.readFile(filename, 'utf-8', (err, data) => {
             res.end(data);
+            fs.unlinkSync(filename);
         });
     });
 });

--- a/sections/production/createmaintenanceendpoint.french.md
+++ b/sections/production/createmaintenanceendpoint.french.md
@@ -11,7 +11,7 @@ Un point de terminaison de maintenance est une API HTTP hautement sécurisée qu
 ### Exemple de code : génération d'un vidage mémoire via du code
 
 ```javascript
-const heapdump = require('heapdump');
+const fs = require("fs");
 
 // Vérifie si la requête est autorisée
 function isAuthorized(req) {
@@ -25,10 +25,12 @@ router.get('/ops/heapdump', (req, res, next) => {
 
     logger.info('À propos de la génération du vidage mémoire');
 
+    const heapdump = require('heapdump');
     heapdump.writeSnapshot((err, filename) => {
         console.log('le fichier heapdump est prêt à être envoyé au demandeur', filename);
         fs.readFile(filename, 'utf-8', (err, data) => {
             res.end(data);
+            fs.unlinkSync(filename);
         });
     });
 });

--- a/sections/production/createmaintenanceendpoint.japanese.md
+++ b/sections/production/createmaintenanceendpoint.japanese.md
@@ -11,7 +11,7 @@
 ### コード例: コードによるヒープダンプの生成
 
 ```javascript
-const heapdump = require('heapdump');
+const fs = require("fs");
 
 // リクエストが許可されているかどうかを確認する
 function isAuthorized(req) {
@@ -25,10 +25,12 @@ router.get('/ops/heapdump', (req, res, next) => {
 
     logger.info('About to generate heapdump');
 
+    const heapdump = require('heapdump');
     heapdump.writeSnapshot((err, filename) => {
         console.log('heapdump file is ready to be sent to the caller', filename);
         fs.readFile(filename, 'utf-8', (err, data) => {
             res.end(data);
+            fs.unlinkSync(filename);
         });
     });
 });

--- a/sections/production/createmaintenanceendpoint.korean.md
+++ b/sections/production/createmaintenanceendpoint.korean.md
@@ -11,7 +11,7 @@ A maintenance endpoint is a highly secure HTTP API that is part of the app code 
 ### Code example: generating a heap dump via code
 
 ```javascript
-const heapdump = require('heapdump');
+const fs = require("fs");
 
 // Check if request is authorized 
 function isAuthorized(req) {
@@ -25,10 +25,12 @@ router.get('/ops/heapdump', (req, res, next) => {
 
     logger.info('About to generate heapdump');
 
+    const heapdump = require('heapdump');
     heapdump.writeSnapshot((err, filename) => {
         console.log('heapdump file is ready to be sent to the caller', filename);
         fs.readFile(filename, "utf-8", (err, data) => {
             res.end(data);
+            fs.unlinkSync(filename);
         });
     });
 });

--- a/sections/production/createmaintenanceendpoint.md
+++ b/sections/production/createmaintenanceendpoint.md
@@ -11,7 +11,7 @@ A maintenance endpoint is a highly secure HTTP API that is part of the app code 
 ### Code example: generating a heap dump via code
 
 ```javascript
-const heapdump = require('heapdump');
+const fs = require("fs");
 
 // Check if request is authorized 
 function isAuthorized(req) {
@@ -25,10 +25,12 @@ router.get('/ops/heapdump', (req, res, next) => {
 
     logger.info('About to generate heapdump');
 
+    const heapdump = require('heapdump');
     heapdump.writeSnapshot((err, filename) => {
         console.log('heapdump file is ready to be sent to the caller', filename);
         fs.readFile(filename, 'utf-8', (err, data) => {
             res.end(data);
+            fs.unlinkSync(filename);
         });
     });
 });

--- a/sections/production/createmaintenanceendpoint.polish.md
+++ b/sections/production/createmaintenanceendpoint.polish.md
@@ -11,7 +11,7 @@ Punkt końcowy konserwacji to wysoce bezpieczny interfejs API HTTP, który jest 
 ### Przykład kodu: generowanie zrzutu sterty za pomocą kodu
 
 ```javascript
-const heapdump = require('heapdump');
+const fs = require("fs");
 
 // Check if request is authorized 
 function isAuthorized(req) {
@@ -25,10 +25,12 @@ router.get('/ops/heapdump', (req, res, next) => {
 
     logger.info('About to generate heapdump');
 
+    const heapdump = require('heapdump');
     heapdump.writeSnapshot((err, filename) => {
         console.log('heapdump file is ready to be sent to the caller', filename);
         fs.readFile(filename, 'utf-8', (err, data) => {
             res.end(data);
+            fs.unlinkSync(filename);
         });
     });
 });

--- a/sections/production/createmaintenanceendpoint.russian.md
+++ b/sections/production/createmaintenanceendpoint.russian.md
@@ -11,7 +11,7 @@
 ### Пример кода: создание дампа кучи с помощью кода
 
 ```javascript
-const heapdump = require('heapdump');
+const fs = require("fs");
 
 // Check if request is authorized 
 function isAuthorized(req) {
@@ -25,10 +25,12 @@ router.get('/ops/heapdump', (req, res, next) => {
 
     logger.info('About to generate heapdump');
 
+    const heapdump = require('heapdump');
     heapdump.writeSnapshot((err, filename) => {
         console.log('heapdump file is ready to be sent to the caller', filename);
         fs.readFile(filename, 'utf-8', (err, data) => {
             res.end(data);
+            fs.unlinkSync(filename);
         });
     });
 });


### PR DESCRIPTION
Defer heapdump Import & Clean Up Temporary Files
- Deferred Import: Moved require('heapdump') inside the route handler so it’s only loaded when needed.
  - Motivation:
    - Avoid V8 Patching & Memory Leaks Requiring the heapdump module patches globals in V8, which—if loaded at startup—can lead to subtle memory leaks over time.  Deferring the import ensures those patches only happen during the actual dump operation.
- Resource Cleanup: Added fs.unlink(...) to delete the generated heapdump file after it’s been sent to the client.
  - Motivation:
    - Prevent Disk Usage Buildup Each heap snapshot can be quite large. Automatically deleting the file once it’s sent avoids filling up disk space when the endpoint is called repeatedly.

