### PR TITLE
fix: correct last-update badge alt text to match URL-encoded dates

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 <br/>
 
 <div align="center">
-  <img src="https://img.shields.io/badge/⚙%20Item%20count%20-%20102%20Best%20Practices-blue.svg" alt="102 items"/> <img id="last-update-badge" src="https://img.shields.io/badge/%F0%9F%93%85%20Last%20update%20-%20January%2024%2C%202023-green.svg" alt="Last update: January 3rd, 2024" /> <img src="https://img.shields.io/badge/ %E2%9C%94%20Updated%20For%20Version%20-%20Node%2022.0.0-brightgreen.svg" alt="Updated for Node 22.0.0"/>
+  <img src="https://img.shields.io/badge/⚙%20Item%20count%20-%20102%20Best%20Practices-blue.svg" alt="102 items"/> <img id="last-update-badge" src="https://img.shields.io/badge/%F0%9F%93%85%20Last%20update%20-%20January%2024%2C%202023-green.svg" alt="Last update: January 24, 2023" /> <img src="https://img.shields.io/badge/ %E2%9C%94%20Updated%20For%20Version%20-%20Node%2022.0.0-brightgreen.svg" alt="Updated for Node 22.0.0"/>
 </div>
 
 <br/>

--- a/README.polish.md
+++ b/README.polish.md
@@ -9,7 +9,7 @@
 <br/>
 
 <div align="center">
-  <img src="https://img.shields.io/badge/⚙%20Item%20count%20-%2085%20Best%20Practices-blue.svg" alt="85 items"/> <img src="https://img.shields.io/badge/%F0%9F%93%85%20Last%20update%20-%20November%2012%202019-green.svg" alt="Last update: Oct 12, 2019"/> <img src="https://img.shields.io/badge/ %E2%9C%94%20Updated%20For%20Version%20-%20Node%2012.12.0-brightgreen.svg" alt="Updated for Node 12.12.0"/>
+  <img src="https://img.shields.io/badge/⚙%20Item%20count%20-%2085%20Best%20Practices-blue.svg" alt="85 items"/> <img src="https://img.shields.io/badge/%F0%9F%93%85%20Last%20update%20-%20November%2012%202019-green.svg" alt="Last update: November 12, 2019"/> <img src="https://img.shields.io/badge/ %E2%9C%94%20Updated%20For%20Version%20-%20Node%2012.12.0-brightgreen.svg" alt="Updated for Node 12.12.0"/>
 </div>
 
 <br/>

--- a/README.russian.md
+++ b/README.russian.md
@@ -9,7 +9,7 @@
 <br/>
 
 <div align="center">
-  <img src="https://img.shields.io/badge/⚙%20Item%20count%20-%2085%20Best%20Practices-blue.svg" alt="85 items"/> <img src="https://img.shields.io/badge/%F0%9F%93%85%20Last%20update%20-%20November%2012%202019-green.svg" alt="Last update: Oct 12, 2019"/> <img src="https://img.shields.io/badge/ %E2%9C%94%20Updated%20For%20Version%20-%20Node%2012.12.0-brightgreen.svg" alt="Updated for Node 12.12.0"/>
+  <img src="https://img.shields.io/badge/⚙%20Item%20count%20-%2085%20Best%20Practices-blue.svg" alt="85 items"/> <img src="https://img.shields.io/badge/%F0%9F%93%85%20Last%20update%20-%20November%2012%202019-green.svg" alt="Last update: November 12, 2019"/> <img src="https://img.shields.io/badge/ %E2%9C%94%20Updated%20For%20Version%20-%20Node%2012.12.0-brightgreen.svg" alt="Updated for Node 12.12.0"/>
 </div>
 
 <br/>


### PR DESCRIPTION
## Summary

Fixes #1354

Three README files had `alt` text for the "last update" badge that did not match the date encoded in the badge image URL. This produces misleading information for screen readers and anyone who inspects the image source.

## Changes

| File | Old alt text | New alt text | Badge URL date |
|------|-------------|-------------|---------------|
| `README.md` | `Last update: January 3rd, 2024` | `Last update: January 24, 2023` | `January%2024%2C%202023` |
| `README.polish.md` | `Last update: Oct 12, 2019` | `Last update: November 12, 2019` | `November%2012%202019` |
| `README.russian.md` | `Last update: Oct 12, 2019` | `Last update: November 12, 2019` | `November%2012%202019` |

## Why this matters

- Screen readers announce the `alt` text rather than the visible badge, so incorrect alt text provides wrong information to accessibility users
- The badge URL is the ground truth for the actual update date; the alt text should reflect it faithfully

## Verification

The corrected dates were obtained by URL-decoding the `img` src in each file:
- `https://img.shields.io/badge/Last%20update-January%2024%2C%202023-green` → January 24, 2023
- `https://img.shields.io/badge/Last%20update-November%2012%202019-green` → November 12, 2019