### PR TITLE
fix: harden GitHub Actions workflows

### DIFF
--- a/.github/workflows/update-date-in-last-update-badge.yml
+++ b/.github/workflows/update-date-in-last-update-badge.yml
@@ -24,7 +24,7 @@ jobs:
           "${GITHUB_WORKSPACE}/.github/workflows/update-last-update-badge.sh" "${GITHUB_WORKSPACE}/README.md"
 
       - name: Commit & Create Pull Request
-        uses: peter-evans/create-pull-request@v4
+        uses: peter-evans/create-pull-request@38e0b6e68b4c852a5500a94740f0e535e0d7ba54 # v4
         with:
           commit-message: update the last update badge to today [skip ci]
           author: Update Last Update Badge Action <${{ github.actor }}@users.noreply.github.com>


### PR DESCRIPTION
Re-submission of #1366. Had a problem with my fork and had to delete it, which closed the original PR. Apologies for the noise.

## Summary

This PR pins all GitHub Actions to immutable commit SHAs instead of mutable version tags and extracts any unsafe expressions from run blocks into env mappings.

## How to verify

Review the diff, each change is mechanical and preserves workflow behavior:
- **SHA pinning**: `action@v3` becomes `action@abc123 # v3`, original version preserved as comment
- No workflow logic, triggers, or permissions are modified

I've been researching CI/CD supply chain attack vectors and submitting fixes to affected repos. Based on that research I built a scanner called Runner Guard and open sourced it [here](https://github.com/Vigilant-LLC/runner-guard) so you can scan yourself if you want to. I'll be posting more advisories over the next few weeks [on Twitter](https://x.com/vigilance_one) if you want to stay in the loop.

If you have any questions, reach out. I'll be monitoring comms.

\- Chris (dagecko)