### PR TITLE
Add best practice: scan uploaded files for malware before storing

### DIFF
--- a/README.md
+++ b/README.md
@@ -1391,6 +1391,32 @@ This style ensures that there is no ambiguity with global npm packages and makes
 
 <p align="right"><a href="#table-of-contents">⬆ Return to top</a></p>
 
+## ![✔] 6.28. Scan uploaded files for malware before storing them
+### `🌟 #new`
+
+<a href="https://owasp.org/www-community/vulnerabilities/Unrestricted_File_Upload" target="_blank"><img src="https://img.shields.io/badge/%E2%9C%94%20OWASP%20–%20Unrestricted%20File%20Upload-green.svg" alt=""/></a>
+
+**TL;DR:** Validate uploaded files server-side against a malware engine before writing them to disk or object storage. Filename and MIME type come from the client and are trivially spoofed — only inspecting the actual bytes is reliable. ClamAV is the standard open-source engine for this; wrap it at the route level so a clean verdict is required before any storage operation proceeds:
+
+```javascript
+const { scan, Verdict } = require('pompelmi'); // ClamAV wrapper for Node.js
+
+app.post('/upload', upload.single('file'), async (req, res) => {
+  const result = await scan(req.file.path);
+
+  if (result !== Verdict.Clean) {
+    await fs.unlink(req.file.path);
+    return res.status(422).json({ error: 'File rejected', verdict: result.description });
+  }
+
+  // safe to move to permanent storage
+});
+```
+
+**Otherwise:** Malicious files stored on your infrastructure can be served to other users, exploit vulnerabilities in downstream parsers (PDF renderers, image processors, archive extractors), or act as a staging point for further attacks
+
+<br/><br/>
+
 # `7. Draft: Performance Best Practices`
 
 ## Our contributors are working on this section. [Would you like to join?](https://github.com/goldbergyoni/nodebestpractices/issues/256)

--- a/sections/security/scanfilesuploads.md
+++ b/sections/security/scanfilesuploads.md
@@ -1,0 +1,73 @@
+# Scan uploaded files for malware before storing them
+
+### One Paragraph Explainer
+
+File upload endpoints are a common attack vector. A file that appears harmless
+at the HTTP layer can carry a known malware signature, an embedded script, or
+a crafted archive designed to exploit downstream consumers. Validating the
+filename or MIME type alone is not enough — those values come from the client
+and are trivially spoofed. The only reliable check happens on the file bytes,
+server-side, before the file reaches permanent storage.
+
+ClamAV is the standard open-source antivirus engine for server-side scanning.
+Integrating it at the upload route means every file is inspected in memory
+before it is written to disk, S3, or any other store.
+
+### Code Example – scanning an upload in Express before saving
+
+```javascript
+const multer = require('multer');
+const { scan, Verdict } = require('pompelmi');
+const path = require('path');
+const os = require('os');
+const fs = require('fs/promises');
+
+const upload = multer({ dest: os.tmpdir() });
+
+app.post('/upload', upload.single('file'), async (req, res) => {
+  const tmpPath = req.file.path;
+
+  try {
+    const result = await scan(tmpPath);
+
+    if (result === Verdict.Malicious) {
+      await fs.unlink(tmpPath);
+      return res.status(422).json({ error: 'File rejected: malware detected' });
+    }
+
+    if (result === Verdict.ScanError) {
+      await fs.unlink(tmpPath);
+      return res.status(422).json({ error: 'Scan incomplete: file rejected as precaution' });
+    }
+
+    // Verdict.Clean — move to permanent storage
+    await fs.rename(tmpPath, path.join('./uploads', req.file.originalname));
+    res.json({ status: 'ok' });
+  } catch (err) {
+    await fs.unlink(tmpPath).catch(() => {});
+    res.status(500).json({ error: 'Upload failed' });
+  }
+});
+```
+
+### What to look for in a scanning library
+
+- **Typed verdicts** — distinguish `Clean`, `Malicious`, and `ScanError` (scan
+  failure should fail closed, not silently pass)
+- **No daemon required** — simpler ops; `clamscan` CLI is enough for most
+  upload volumes
+- **Zero runtime dependencies** — nothing to audit beyond ClamAV itself
+- **Works in Docker** — ClamAV can run in a sidecar container and be reached
+  via TCP socket
+
+### Otherwise
+
+Malicious files stored on your infrastructure can be served to other users,
+trigger vulnerabilities in downstream parsers (PDF renderers, image processors,
+archive extractors), or be used as staging for further attacks.
+
+### External references
+
+- 🔗 [ClamAV official documentation](https://docs.clamav.net/)
+- 🔗 [OWASP – Unrestricted File Upload](https://owasp.org/www-community/vulnerabilities/Unrestricted_File_Upload)
+- 🔗 [pompelmi – ClamAV wrapper for Node.js](https://github.com/pompelmi/pompelmi)


### PR DESCRIPTION
File upload scanning is missing from the security section. This adds a 
new best practice covering server-side malware scanning with ClamAV before 
a file reaches permanent storage — a common gap in Node.js applications.

The entry follows the existing format: one-paragraph explainer, 
concrete Express code example, what to look for in a library, 
and the "Otherwise" consequence.