### PR TITLE
chore(deps): 1 outdated dependency. markdownlint-cli from 0.18.0 → 0.40.x (minor rang

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,6 @@
   },
   "homepage": "https://github.com/goldbergyoni/nodebestpractices#readme",
   "dependencies": {
-    "markdownlint-cli": "^0.18.0"
+    "markdownlint-cli": "^0.40.0"
   }
 }


### PR DESCRIPTION
## 🔧 依赖维护更新 — goldbergyoni/nodebestpractices

此 PR 由 **Code Legacy Reviver** 自动生成🤖

### 📋 更新摘要

1 outdated dependency. markdownlint-cli from 0.18.0 → 0.40.x (minor range upgrade, same major version, low risk). This project has only 1 dependency and appears to be a documentation linter setup.

### 📦 变更清单

🟡 **markdownlint-cli**: `^0.18.0` → `^0.40.0`
  _0.18.0 is from ~2019, latest 0.x is 0.40+ with bug fixes and Node.js version compatibility improvements. Safe minor-range upgrade._

### ⚠️ 风险等级
🟢 **Low**

### 📝 文件变更
- `package.json`

---
_Generated by [Code Legacy Reviver](https://github.com/isagoakira/code-legacy-reviver)_