### PR TITLE
chore(deps): 1 outdated dep found. markdownlint-cli 0.18→0.38+ (major version jump, p

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,6 @@
   },
   "homepage": "https://github.com/goldbergyoni/nodebestpractices#readme",
   "dependencies": {
-    "markdownlint-cli": "^0.18.0"
+    "markdownlint-cli": "^0.38.0"
   }
 }


### PR DESCRIPTION
## 🔧 依赖维护更新 — goldbergyoni/nodebestpractices

此 PR 由 **Code Legacy Reviver** 自动生成🤖

### 📋 更新摘要

1 outdated dep found. markdownlint-cli 0.18→0.38+ (major version jump, proceed with caution — verify CLI arguments and rule config compatibility). No other dependencies present.

### 📦 变更清单

🟡 **markdownlint-cli**: `^0.18.0` → `^0.38.0`
  _0.18.0 released ~2019, current versions are 0.38+ with many improvements, rule additions, and bug fixes. Version range constraint allows safe upgrade within same major version._

### ⚠️ 风险等级
🟡 **Medium**

### 📝 文件变更
- `package.json`

---
_Generated by [Code Legacy Reviver](https://github.com/isagoakira/code-legacy-reviver)_