### PR TITLE
chore(deps): 1 outdated dep found. markdownlint-cli 0.18.0 is 6+ years old with many 

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,6 @@
   },
   "homepage": "https://github.com/goldbergyoni/nodebestpractices#readme",
   "dependencies": {
-    "markdownlint-cli": "^0.18.0"
+    "markdownlint-cli": "^0.40.0"
   }
 }


### PR DESCRIPTION
## 🔧 依赖维护更新 — goldbergyoni/nodebestpractices

此 PR 由 **Code Legacy Reviver** 自动生成🤖

### 📋 更新摘要

1 outdated dep found. markdownlint-cli 0.18.0 is 6+ years old with many bug fixes in the 0.x line. Upgrade to 0.40.0 (latest 0.x) first; jumping to 1.x+ may introduce breaking changes.

### 📦 变更清单

🟡 **markdownlint-cli**: `^0.18.0` → `^0.40.0`
  _0.18.0 released 2019 (6+ years old). Current 0.x branch is 0.40.0 with bug fixes, improved config handling, and updated dependencies. Major version jump to 1.x+ riskier due to API changes._

### ⚠️ 风险等级
🟡 **Medium**

### 📝 文件变更
- `package.json`

---
_Generated by [Code Legacy Reviver](https://github.com/isagoakira/code-legacy-reviver)_