### PR TITLE
chore(deps): 1 outdated dep found. markdownlint-cli 0.18.0 → 0.40.0 (22+ minor versio

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,6 @@
   },
   "homepage": "https://github.com/goldbergyoni/nodebestpractices#readme",
   "dependencies": {
-    "markdownlint-cli": "^0.18.0"
+    "markdownlint-cli": "^0.40.0"
   }
 }


### PR DESCRIPTION
## 🔧 依赖维护更新 — goldbergyoni/nodebestpractices

此 PR 由 **Code Legacy Reviver** 自动生成🤖

### 📋 更新摘要

1 outdated dep found. markdownlint-cli 0.18.0 → 0.40.0 (22+ minor versions, significant jump within 0.x semver). Verify CLI flags/compatibility after upgrade.

### 📦 变更清单

🔴 **markdownlint-cli**: `^0.18.0` → `^0.40.0`
  _0.18.0 from 2019 is ~22 minor versions behind. The package has had many updates including bug fixes and potential breaking changes. Major bump within 0.x, test after upgrade._

### ⚠️ 风险等级
🟡 **Medium**

### 📝 文件变更
- `package.json`

---
_Generated by [Code Legacy Reviver](https://github.com/isagoakira/code-legacy-reviver)_