### PR TITLE
chore(deps): 1 outdated dep found. markdownlint-cli 0.18→0.40 (major jump within 0.x,

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,6 @@
   },
   "homepage": "https://github.com/goldbergyoni/nodebestpractices#readme",
   "dependencies": {
-    "markdownlint-cli": "^0.18.0"
+    "markdownlint-cli": "^0.40.0"
   }
 }


### PR DESCRIPTION
## 🔧 依赖维护更新 — goldbergyoni/nodebestpractices

此 PR 由 **Code Legacy Reviver** 自动生成🤖

### 📋 更新摘要

1 outdated dep found. markdownlint-cli 0.18→0.40 (major jump within 0.x, requires verification of CLI args and config format)

### 📦 变更清单

🟡 **markdownlint-cli**: `^0.18.0` → `^0.40.0`
  _0.18.0 released ~2019, current 0.x is 0.40.0+ with many improvements and bug fixes. However, this is a significant jump within 0.x range—verify CLI args and config compatibility_

### ⚠️ 风险等级
🟡 **Medium**

### 📝 文件变更
- `package.json`

---
_Generated by [Code Legacy Reviver](https://github.com/isagoakira/code-legacy-reviver)_