### PR TITLE
chore(deps): 1 outdated dependency found. markdownlint-cli 0.18→0.38 (~20 minor versi

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,6 @@
   },
   "homepage": "https://github.com/goldbergyoni/nodebestpractices#readme",
   "dependencies": {
-    "markdownlint-cli": "^0.18.0"
+    "markdownlint-cli": "^0.38.0"
   }
 }


### PR DESCRIPTION
## 🔧 依赖维护更新 — goldbergyoni/nodebestpractices

此 PR 由 **Code Legacy Reviver** 自动生成🤖

### 📋 更新摘要

1 outdated dependency found. markdownlint-cli 0.18→0.38 (~20 minor versions behind). Major version jump may carry minor breaking changes in CLI output formats; test after upgrade.

### 📦 变更清单

🟡 **markdownlint-cli**: `^0.18.0` → `^0.38.0`
  _0.18.0 released ~2019, current stable is 0.38.x with bug fixes and Node.js compatibility improvements_

### ⚠️ 风险等级
🟡 **Medium**

### 📝 文件变更
- `package.json`

---
_Generated by [Code Legacy Reviver](https://github.com/isagoakira/code-legacy-reviver)_