### PR TITLE
chore(deps): markdownlint-cli 0.18.0 appears outdated (released ~2018), but I'm not c

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,6 @@
   },
   "homepage": "https://github.com/goldbergyoni/nodebestpractices#readme",
   "dependencies": {
-    "markdownlint-cli": "^0.18.0"
+    "markdownlint-cli": "unsure"
   }
 }


### PR DESCRIPTION
## 🔧 依赖维护更新 — goldbergyoni/nodebestpractices

此 PR 由 **Code Legacy Reviver** 自动生成🤖

### 📋 更新摘要

markdownlint-cli 0.18.0 appears outdated (released ~2018), but I'm not confident about recommending a specific safe upgrade target without more research. The package has likely moved to 0.30+ but I cannot confirm breaking change risk.

### 📦 变更清单

🟢 **markdownlint-cli**: `^0.18.0` → `unsure`
  _0.18.0 is from 2018, but I'm uncertain about the current latest stable version and potential breaking changes in this major-minor jump. Version 0.18→0.30+ spans many releases._

### ⚠️ 风险等级
🔴 **High**

### 📝 文件变更
- `package.json`

---
_Generated by [Code Legacy Reviver](https://github.com/isagoakira/code-legacy-reviver)_