### PR TITLE
chore(deps): 1 outdated dependency found. markdownlint-cli 0.18.0→0.41.0 (22+ minor v

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,6 @@
   },
   "homepage": "https://github.com/goldbergyoni/nodebestpractices#readme",
   "dependencies": {
-    "markdownlint-cli": "^0.18.0"
+    "markdownlint-cli": "^0.41.0"
   }
 }


### PR DESCRIPTION
## 🔧 依赖维护更新 — goldbergyoni/nodebestpractices

此 PR 由 **Code Legacy Reviver** 自动生成🤖

### 📋 更新摘要

1 outdated dependency found. markdownlint-cli 0.18.0→0.41.0 (22+ minor versions behind, but semver-safe minor bumps)

### 📦 变更清单

🔴 **markdownlint-cli**: `^0.18.0` → `^0.41.0`
  _0.18.0 released ~2019, current 0.41.x has numerous improvements and bug fixes. Versioning is minor-patch only (no breaking API changes expected for CLI tool)_

### ⚠️ 风险等级
🟢 **Low**

### 📝 文件变更
- `package.json`

---
_Generated by [Code Legacy Reviver](https://github.com/isagoakira/code-legacy-reviver)_