### PR TITLE
chore(deps): 1 outdated dependency found. markdownlint-cli 0.18→0.31 (major bump, con

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,6 @@
   },
   "homepage": "https://github.com/goldbergyoni/nodebestpractices#readme",
   "dependencies": {
-    "markdownlint-cli": "^0.18.0"
+    "markdownlint-cli": "^0.31.1"
   }
 }


### PR DESCRIPTION
## 🔧 依赖维护更新 — goldbergyoni/nodebestpractices

此 PR 由 **Code Legacy Reviver** 自动生成🤖

### 📋 更新摘要

1 outdated dependency found. markdownlint-cli 0.18→0.31 (major bump, contains breaking changes - review before upgrading)

### 📦 变更清单

🟡 **markdownlint-cli**: `^0.18.0` → `^0.31.1`
  _0.18.0 is from 2019, multiple security and bug fixes in later versions_

### ⚠️ 风险等级
🟡 **Medium**

### 📝 文件变更
- `package.json`

---
_Generated by [Code Legacy Reviver](https://github.com/isagoakira/code-legacy-reviver)_