### PR TITLE
chore(deps): 1 outdated dep found. markdownlint-cli 0.18.0 → 0.33.0 (15 minor version

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,6 @@
   },
   "homepage": "https://github.com/goldbergyoni/nodebestpractices#readme",
   "dependencies": {
-    "markdownlint-cli": "^0.18.0"
+    "markdownlint-cli": "^0.33.0"
   }
 }


### PR DESCRIPTION
## 🔧 依赖维护更新 — goldbergyoni/nodebestpractices

此 PR 由 **Code Legacy Reviver** 自动生成🤖

### 📋 更新摘要

1 outdated dep found. markdownlint-cli 0.18.0 → 0.33.0 (15 minor versions behind, all within 0.x stable range)

### 📦 变更清单

🟡 **markdownlint-cli**: `^0.18.0` → `^0.33.0`
  _0.18.0 is from 2019, latest stable is 0.33.x with numerous bug fixes and compatibility improvements. Safe minor upgrade within 0.x semver range._

### ⚠️ 风险等级
🟢 **Low**

### 📝 文件变更
- `package.json`

---
_Generated by [Code Legacy Reviver](https://github.com/isagoakira/code-legacy-reviver)_