### PR TITLE
chore(deps): 1 outdated dep found. markdownlint-cli 0.18.0→0.36.0 (18 minor versions 

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,6 @@
   },
   "homepage": "https://github.com/goldbergyoni/nodebestpractices#readme",
   "dependencies": {
-    "markdownlint-cli": "^0.18.0"
+    "markdownlint-cli": "^0.36.0"
   }
 }


### PR DESCRIPTION
## 🔧 依赖维护更新 — goldbergyoni/nodebestpractices

此 PR 由 **Code Legacy Reviver** 自动生成🤖

### 📋 更新摘要

1 outdated dep found. markdownlint-cli 0.18.0→0.36.0 (18 minor versions behind, CLI tool with low breaking change risk due to 0.x semver).

### 📦 变更清单

🟡 **markdownlint-cli**: `^0.18.0` → `^0.36.0`
  _0.18.0 released ~2019, current 0.36.x includes bug fixes, security patches, and Node.js version support updates. Still 0.x semver range (low breaking change risk)._

### ⚠️ 风险等级
🟡 **Medium**

### 📝 文件变更
- `package.json`

---
_Generated by [Code Legacy Reviver](https://github.com/isagoakira/code-legacy-reviver)_