### PR TITLE
chore(deps): 1 outdated dependency found. markdownlint-cli 0.18.0→0.36.0 crosses many

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,6 @@
   },
   "homepage": "https://github.com/goldbergyoni/nodebestpractices#readme",
   "dependencies": {
-    "markdownlint-cli": "^0.18.0"
+    "markdownlint-cli": "^0.36.0"
   }
 }


### PR DESCRIPTION
## 🔧 依赖维护更新 — goldbergyoni/nodebestpractices

此 PR 由 **Code Legacy Reviver** 自动生成🤖

### 📋 更新摘要

1 outdated dependency found. markdownlint-cli 0.18.0→0.36.0 crosses many major versions—test thoroughly before upgrading.

### 📦 变更清单

🟡 **markdownlint-cli**: `^0.18.0` → `^0.36.0`
  _Version 0.18.0 is from 2019 and 18+ minor versions behind. Latest 0.36.x contains security fixes and improvements. However, this is a large jump (0.18→0.36) with likely breaking changes._

### ⚠️ 风险等级
🟡 **Medium**

### 📝 文件变更
- `package.json`

---
_Generated by [Code Legacy Reviver](https://github.com/isagoakira/code-legacy-reviver)_