### PR TITLE
chore(deps): 1 dependency identified as outdated. markdownlint-cli 0.18.0 (2019) → la

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,6 @@
   },
   "homepage": "https://github.com/goldbergyoni/nodebestpractices#readme",
   "dependencies": {
-    "markdownlint-cli": "^0.18.0"
+    "markdownlint-cli": "^0.40.0"
   }
 }


### PR DESCRIPTION
## 🔧 依赖维护更新 — goldbergyoni/nodebestpractices

此 PR 由 **Code Legacy Reviver** 自动生成🤖

### 📋 更新摘要

1 dependency identified as outdated. markdownlint-cli 0.18.0 (2019) → latest 0.40.x. Both are 0.x semver so technically minor, but verify after upgrade.

### 📦 变更清单

🟡 **markdownlint-cli**: `^0.18.0` → `^0.40.0`
  _0.18.0 is from 2019, latest 0.x versions include security fixes and Node.js compatibility updates. However, this is a jump of ~22 minor versions within 0.x, so test after upgrade._

### ⚠️ 风险等级
🟡 **Medium**

### 📝 文件变更
- `package.json`

---
_Generated by [Code Legacy Reviver](https://github.com/isagoakira/code-legacy-reviver)_