### PR TITLE
docs(#1374): add English version of separateexpress documentation

### DIFF
--- a/sections/projectstructre/separateexpress.md
+++ b/sections/projectstructre/separateexpress.md
@@ -1,0 +1,61 @@
+# Separate Express 'app' and 'server'
+
+<br/><br/>
+
+### One Paragraph Explainer
+
+The latest Express generator comes with a great practice worth keeping — the API declaration is separated from the network-related configuration (port, protocol, etc.). This allows testing the API in-process, without performing network calls, bringing two benefits: faster test execution and getting code coverage metrics. It also allows deploying the same API under flexible and different network conditions. Bonus: better separation of concerns and cleaner code.
+
+<br/><br/>
+
+### Code Example: API declaration, should reside in app.js
+
+```javascript
+var app = express();
+app.use(bodyParser.json());
+app.use("/api/events", events.API);
+app.use("/api/forms", forms);
+```
+
+<br/><br/>
+
+### Code Example: Server network declaration, should reside in /bin/www
+
+```javascript
+var app = require('../app');
+var http = require('http');
+
+/**
+ * Get port from environment and store in Express.
+ */
+
+var port = normalizePort(process.env.PORT || '3000');
+app.set('port', port);
+
+/**
+ * Create HTTP server.
+ */
+
+var server = http.createServer(app);
+```
+
+<br/><br/>
+
+### Code Example: Test your app in-process using a fast and popular testing package
+
+```javascript
+const app = express();
+
+app.get('/user', function(req, res) {
+  res.status(200).json({ name: 'tobi' });
+});
+
+request(app)
+  .get('/user')
+  .expect('Content-Type', /json/)
+  .expect('Content-Length', '15')
+  .expect(200)
+  .end(function(err, res) {
+    if (err) throw err;
+  });
+```


### PR DESCRIPTION
Closes #1374

## Summary

Adds the missing English documentation file `sections/projectstructre/separateexpress.md`.

All other language versions of this file already exist (Basque, Brazilian Portuguese, Chinese, French, Japanese, Korean, Polish, Russian), but the English base version was absent.

The English file explains the best practice of separating the Express `app` declaration from the server/network configuration (`bin/www`), including code examples for:
1. API declaration in `app.js`
2. Server network declaration in `bin/www`
3. In-process testing using supertest

The content follows the same structure as the existing Chinese version and matches the format used by other English files in the same directory (e.g., `breakintcomponents.md`, `configguide.md`).