### PR TITLE
chore(deps): 1 outdated dep found. markdownlint-cli ^0.18.0 → ^0.40.0 (minor+). Note:

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,6 @@
   },
   "homepage": "https://github.com/goldbergyoni/nodebestpractices#readme",
   "dependencies": {
-    "markdownlint-cli": "^0.18.0"
+    "markdownlint-cli": "^0.40.0"
   }
 }


### PR DESCRIPTION
## 🔧 依赖维护更新 — goldbergyoni/nodebestpractices

此 PR 由 **Code Legacy Reviver** 自动生成🤖

### 📋 更新摘要

1 outdated dep found. markdownlint-cli ^0.18.0 → ^0.40.0 (minor+). Note: ^0.x semver treats this as a major boundary, so verify the upgrade doesn't break your lint rules after upgrading.

### 📦 变更清单

🟡 **markdownlint-cli**: `^0.18.0` → `^0.40.0`
  _0.18.0 is from 2019. Latest major version is 0.40+ with many improvements, bug fixes, and updated transitive deps. Staying within ^0.x range is safe._

### ⚠️ 风险等级
🟡 **Medium**

### 📝 文件变更
- `package.json`

---
_Generated by [Code Legacy Reviver](https://github.com/isagoakira/code-legacy-reviver)_